### PR TITLE
Added files to aid in the quickstart for CDC end-to-end pipeline

### DIFF
--- a/cdc-quickstart-kafka-connect/README.md
+++ b/cdc-quickstart-kafka-connect/README.md
@@ -1,0 +1,83 @@
+# YugabyteDB CDC Pipeline
+
+This repository contains simple steps to set up a YugabyteDB CDC pipeline to get the data from YSQL to a Kafka topic
+
+## Running the CDC pipeline
+The following example uses a PostgreSQL database as the sink database, which will be populated using a JDBC Sink Connector.
+
+1. Start YugabyteDB
+  This can be a local instance as well as a universe running on Yugabyte Anywhere. All you need is the IP of the nodes where the tserver and master processes are running.
+  ```sh
+  export NODE=172.165.31.198
+  export MASTERS=172.165.31.198:7100
+  ```
+2. Create a table
+  ```sql
+  CREATE TABLE employee (id INT PRIMARY KEY, first_name TEXT, last_name TEXT, dept_id SMALLINT);
+  ```
+3. Create a stream ID using yb-admin
+  ```
+  ./yb-admin --master_addresses $MASTERS create_change_data_stream ysql.<namespace>
+  ```
+4. Start the docker containers
+  ```sh
+  docker-compose up
+  ```
+5. Deploy the source connector:
+  ```sh
+  curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" localhost:8083/connectors/ -d '{
+    "name": "ybconnector",
+    "config": {
+      "tasks.max":"1",
+      "connector.class": "io.debezium.connector.yugabytedb.YugabyteDBConnector",
+      "database.hostname":"'$NODE'",
+      "database.master.addresses":"'$MASTERS'",
+      "database.port":"5433",
+      "database.user": "yugabyte",
+      "database.password":"yugabyte",
+      "database.dbname":"yugabyte",
+      "database.server.name":"dbserver1",
+      "snapshot.mode":"never",
+      "database.streamid":"4a585fa40740459e907ff7fd67497869",
+      "table.include.list":"public.employee"
+    }
+  }'
+  ```
+  **Note: Change the parameters according to the scenario you're working on.**
+6. Deploy the sink connector
+  ```sh
+  curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" localhost:8083/connectors/ -d @jdbc-sink-pg.json
+  ```
+7. To login to the PostgreSQL terminal, use:
+  ```sh
+  docker run --network=yb-cdc-demo_default -it --rm --name postgresqlterm --link pg:postgresql --rm postgres:11.2 sh -c 'PGPASSWORD=postgres exec psql -h pg -p "$POSTGRES_PORT_5432_TCP_PORT" -U postgres'
+  ```
+8. You can start performing operations on the source now and see them getting replicated in the PostgreSQL table.
+
+## Adding your own connector to the image
+
+If you want to use your own custom connector to the docker image, be ready with the jar file which has all the files required for the connector and follow the given steps:
+
+1. Create a directory
+  ```sh
+  mkdir ~/custom-image
+  ```
+2. Copy the jar file to the directory
+  ```sh
+  cp jarFileXYZ.jar ~/custom-image/
+  ```
+3. Navigate to the directory and create a Dockerfile
+  ```sh
+  cd ~/custom-image && touch Dockerfile
+  ```
+4. Edit the contents of the Dockerfile
+  ```Dockerfile
+  FROM quay.io/yugabyte/debezium-connector:latest
+  
+  COPY jarFileXYZ.jar $KAFKA_CONNECT_PLUGINS_DIR/debezium-connector-yugabytedb/
+  ```
+5. Build your docker image
+  ```sh
+  docker build . -t my-custom-image
+  ```
+  **NOTE: Do not forget to edit the docker-compose file with this custom image name in case you want to use this newly created image with the docker compose commands**

--- a/cdc-quickstart-kafka-connect/docker-compose.yaml
+++ b/cdc-quickstart-kafka-connect/docker-compose.yaml
@@ -1,0 +1,66 @@
+version: "3"
+services:
+  zookeeper:
+    container_name: zookeeper
+    image: debezium/zookeeper:1.7
+    user: "0:0"
+    ports:
+      - 2181:2181
+      - 2888:2888
+      - 3888:3888
+    restart: unless-stopped
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+
+  kafka:
+    container_name: kafka
+    image: debezium/kafka:1.7
+    links:
+      - zookeeper
+    user: "0:0"
+    ports:
+      - 9092:9092
+      - 9099:9099
+    restart: unless-stopped
+    environment:
+      KAFKA_CFG_BROKER_ID: 100
+      ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_CFG_LISTENERS: "CLIENT://:9093,EXTERNAL://:9092"
+      KAFKA_CFG_ADVERTISED_LISTENERS: "CLIENT://:9093,EXTERNAL://kafka:9092"
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT"
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: CLIENT
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_OPTS: -Djdk.tls.client.protocols=TLSv1.2
+  
+  kafka-connect:
+    container_name: kafka-connect
+    image: quay.io/yugabyte/debezium-connector:latest
+    depends_on: [ zookeeper, kafka ]
+    ports:
+      - 8083:8083
+    restart: unless-stopped
+    environment:
+      BOOTSTRAP_SERVERS: "kafka:9092"
+      GROUP_ID: kafka-connect-group
+      CONFIG_STORAGE_TOPIC: kafka-connect_configs
+      CONFIG_STORAGE_REPLICATION_FACTOR: 1
+      OFFSET_STORAGE_TOPIC: kafka-connect_offset
+      OFFSET_STORAGE_REPLICATION_FACTOR: 1
+      STATUS_STORAGE_TOPIC: kafka-connect_status
+      STATUS_STORAGE_REPLICATION_FACTOR: 1
+      REST_ADVERTISED_HOST_NAME: kafka-connect
+      CONNECT_REST_PORT: 8083
+  
+  pg:
+    container_name: pg
+    image: debezium/example-postgres:1.7
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres

--- a/cdc-quickstart-kafka-connect/jdbc-sink-pg.json
+++ b/cdc-quickstart-kafka-connect/jdbc-sink-pg.json
@@ -1,0 +1,20 @@
+{
+  "name": "jdbc-sink-pg",
+  "config": {
+    "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",    
+     "tasks.max": "1",
+      "topics": "dbserver1.public.employee",
+      "dialect.name": "PostgreSqlDatabaseDialect",    
+      "table.name.format": "employee",    
+      "connection.url": "jdbc:postgresql://pg:5432/postgres?user=postgres&password=postgres&sslMode=require",    
+      "transforms": "unwrap",    
+      "transforms.unwrap.type": "io.debezium.connector.yugabytedb.transforms.YBExtractNewRecordState",    
+      "transforms.unwrap.drop.tombstones": "false",
+      "auto.create": "true",   
+      "insert.mode": "upsert",    
+      "pk.fields": "id",    
+      "pk.mode": "record_key",   
+      "delete.enabled": "true",
+      "auto.evolve":"true"
+   }
+}


### PR DESCRIPTION
This PR adds README and the relevant docker-compose files which will help in case someone wants to quickly try out the CDC pipeline without going in depth of too many steps.

Simply setup containers using the docker-compose file and follow the instructions in the README.