### PR TITLE
Add fix for docker not being able to connect to local network

### DIFF
--- a/cdc-quickstart-kafka-connect/README.md
+++ b/cdc-quickstart-kafka-connect/README.md
@@ -133,7 +133,7 @@ The docker compose command will bring up the containers for Prometheus and Grafa
     rm -rf zookeeper/zookeeper_log/*
   ```
 
-* __Unable to deploy connectors locally__
+* __Unable to deploy connectors locally on MacOS__
 
   If the command to deploy source connectors (`./deploy-sources.sh <stream-id-created-in-step-3>`) is failing, given you're using docker on MacOS and trying to connect to yugabyteDB instance that is deployed on your local network, it is happening probably because your docker containers are unable to access your local network. You can install something like [docker-mac-net-connect](https://github.com/chipmk/docker-mac-net-connect) to fix this issue.
 

--- a/cdc-quickstart-kafka-connect/README.md
+++ b/cdc-quickstart-kafka-connect/README.md
@@ -132,3 +132,13 @@ The docker compose command will bring up the containers for Prometheus and Grafa
     rm -rf zookeeper/zookeeper_data/*
     rm -rf zookeeper/zookeeper_log/*
   ```
+
+* __Unable to deploy connectors locally__
+
+  If the command to deploy source connectors (`./deploy-sources.sh <stream-id-created-in-step-3>`) is failing, given you're using docker on MacOS and trying to connect to yugabyteDB instance that is deployed on your local network, it is happening probably because your docker containers are unable to access your local network. You can install something like [docker-mac-net-connect](https://github.com/chipmk/docker-mac-net-connect) to fix this issue.
+
+  ```
+    brew install chipmk/tap/docker-mac-net-connect
+    sudo brew services start chipmk/tap/docker-mac-net-connect
+  ```
+

--- a/cdc-quickstart-kafka-connect/README.md
+++ b/cdc-quickstart-kafka-connect/README.md
@@ -141,4 +141,3 @@ The docker compose command will bring up the containers for Prometheus and Grafa
     brew install chipmk/tap/docker-mac-net-connect
     sudo brew services start chipmk/tap/docker-mac-net-connect
   ```
-


### PR DESCRIPTION
As docker runs inside a VM on MacOS, it can't access the local network IPs running on the host itself. It causes problems with the debezium-connector as it is unable to communicate with yugabytedb processes running locally. This issue can be fixed by installing https://github.com/chipmk/docker-mac-net-connect.