### PR TITLE
Fixing metrics regex to adhere to latest format

### DIFF
--- a/cdc-quickstart-kafka-connect/grafana-dashboard/metrics-dashboard.json
+++ b/cdc-quickstart-kafka-connect/grafana-dashboard/metrics-dashboard.json
@@ -111,9 +111,9 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "editorMode": "builder",
-          "expr": "sum by(tablet) (debezium_metrics_totalnumberofeventsseen{context=\"streaming\"})",
+          "expr": "sum by(partition) (debezium_metrics_totalnumberofeventsseen{context=\"streaming\"})",
           "hide": false,
-          "legendFormat": "count for {{tablet}}",
+          "legendFormat": "count for {{partition}}",
           "range": true,
           "refId": "A"
         },
@@ -124,17 +124,17 @@
           },
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "sum by(tablet) (rate(debezium_metrics_totalnumberofeventsseen{context=\"streaming\"}[$__rate_interval]))",
+          "expr": "sum by(partition) (rate(debezium_metrics_totalnumberofeventsseen{context=\"streaming\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
-          "legendFormat": "rate for {{tablet}}",
+          "legendFormat": "rate for {{partition}}",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "debezium_metrics_totalnumberofeventsseen aggregated on tablet level",
+      "title": "debezium_metrics_totalnumberofeventsseen aggregated on partition level",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
Changing the metrics regex and expression being used to evaluate metrics. Earlier we were using `tablet` which has the value `tabletUUID` but now we will be using `partition` which will be having a value `tableUUID.tabletUUID`